### PR TITLE
Add more deprecations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.0.1 (unreleased)
 ------------------
 
-- Deprecate ``zope.site.hooks`` with ``zope.deprecation``.
+- Deprecate ``zope.site.hooks``, ``zope.site.site.setSite`` and ``zope.site.next`` with ``zope.deprecation``.
+  These will be removed in zope.site Version 5.0.
   [thet]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 4.0.1 (unreleased)
 ------------------
 
-- Deprecate ``zope.site.hooks``, ``zope.site.site.setSite`` and ``zope.site.next`` with ``zope.deprecation``.
+- Deprecate ``zope.site.hooks.*``, ``zope.site.site.setSite``, ``zope.site.next.getNextUtility`` and ``zope.site.next.queryNextUtility`` with ``zope.deprecation``.
   These will be removed in zope.site Version 5.0.
   [thet]
 

--- a/src/zope/site/__init__.py
+++ b/src/zope/site/__init__.py
@@ -20,5 +20,10 @@ from zope.site.site import LocalSiteManager, changeSiteConfigurationAfterMove
 from zope.site.site import threadSiteSubscriber
 from zope.site.site import clearThreadSiteSubscriber
 
-# BBB
-from zope.component import getNextUtility, queryNextUtility
+
+# BBB. Remove in Version 5.0
+from zope.component import getNextUtility
+from zope.component import queryNextUtility
+from zope.deprecation import deprecated
+getNextUtility = deprecated(getNextUtility, '``zope.site.getNextUtility`` is deprecated and will be removed in zope.site 5.0. Use it from ``zope.component`` instead.')  # noqa
+queryNextUtility = deprecated(queryNextUtility, '``zope.site.queryNextUtility`` is deprecated and will be removed in zope.site 5.0. Use it from ``zope.component`` instead.')  # noqa

--- a/src/zope/site/hooks.py
+++ b/src/zope/site/hooks.py
@@ -13,6 +13,6 @@
 ##############################################################################
 """Hooks for getting and setting a site in the thread global namespace.
 """
-__docformat__ = 'restructuredtext'
+# BBB. Remove in Version 5.0
 from zope.deprecation import moved
-moved('zope.component.hooks', 'Version 4.1')
+moved('zope.component.hooks', 'Version 5.0')

--- a/src/zope/site/next.py
+++ b/src/zope/site/next.py
@@ -1,2 +1,3 @@
-# BBB
-from zope.component import getNextUtility, queryNextUtility
+# BBB. Remove in Version 5.0
+from zope.deprecation import moved
+moved('zope.component', 'Version 5.0')

--- a/src/zope/site/site.py
+++ b/src/zope/site/site.py
@@ -41,8 +41,11 @@ from zope.container.contained import Contained
 
 from zope.site import interfaces
 
-# BBB
+
+# BBB. Remove in Version 5.0
 from zope.component.hooks import setSite
+from zope.deprecation import deprecated
+setSite = deprecated(setSite, '``zope.site.site.setSite`` is deprecated and will be removed in zope.site Version 5.0. Use it from ``zope.component.hooks`` instead.')  # noqa
 
 
 @zope.interface.implementer(interfaces.ISiteManagementFolder)


### PR DESCRIPTION
Deprecate ``zope.site.hooks``, ``zope.site.site.setSite`` and ``zope.site.next`` with ``zope.deprecation``.
These will be removed in zope.site Version 5.0.

/cc @jensens plz review - you've written the zope.deprecations styleguide for docs.plone.org...