### PR TITLE
On removal of site remove the sub of its site manager from parent site manager

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 4.3.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- On removal of a site remove the sub of its site manager on the parent site
+  manager. See
+  `issue 1 <https://github.com/zopefoundation/zope.site/issues/1>`_.
 
 
 4.3.0 (2020-04-01)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-4.3.1 (unreleased)
+4.4.0 (unreleased)
 ==================
 
 - On removal of a site remove the sub of its site manager on the parent site

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@
 4.4.0 (unreleased)
 ==================
 
-- On removal of a site remove the sub of its site manager on the parent site
-  manager. See
+- On removal of a site, clear the bases of its site manager. This fixes a reference leak 
+  from a parent site manager. See 
   `issue 1 <https://github.com/zopefoundation/zope.site/issues/1>`_.
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ TESTS_REQUIRE = [
 ]
 
 setup(name='zope.site',
-      version='4.3.1.dev0',
+      version='4.4.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Local registries for zope component architecture',

--- a/src/zope/site/site.py
+++ b/src/zope/site/site.py
@@ -242,20 +242,19 @@ def SiteManagerAdapter(ob):
 
 def changeSiteConfigurationAfterMove(site, event):
     """
-    After a site is moved, its site manager links have to be
+    After a site is (re-)moved, its site manager links have to be
     updated.
 
     Subscriber to :class:`~.ISite` objects in a :class:`~.IObjectMovedEvent`.
     """
-    next = _findNextSiteManager(site)
     local_sm = site.getSiteManager()
     if event.newParent is not None:
+        next = _findNextSiteManager(site)
         if next is None:
             next = zope.component.getGlobalSiteManager()
         local_sm.__bases__ = (next, )
     else:
-        if next is not None:
-            next.removeSub(local_sm)
+        local_sm.__bases__ = ()
 
 
 @zope.component.adapter(

--- a/src/zope/site/site.py
+++ b/src/zope/site/site.py
@@ -247,11 +247,15 @@ def changeSiteConfigurationAfterMove(site, event):
 
     Subscriber to :class:`~.ISite` objects in a :class:`~.IObjectMovedEvent`.
     """
+    next = _findNextSiteManager(site)
+    local_sm = site.getSiteManager()
     if event.newParent is not None:
-        next = _findNextSiteManager(site)
         if next is None:
             next = zope.component.getGlobalSiteManager()
-        site.getSiteManager().__bases__ = (next, )
+        local_sm.__bases__ = (next, )
+    else:
+        if next is not None:
+            next.removeSub(local_sm)
 
 
 @zope.component.adapter(

--- a/src/zope/site/site.rst
+++ b/src/zope/site/site.rst
@@ -278,7 +278,7 @@ site hierarchy is as follows:
 
            _____ global site _____
           /                       \
-      myfolder1                myfolder2
+      myfolder                 myfolder2
           |
       myfolder11
 
@@ -352,3 +352,9 @@ sitemanager's bases should be set to global site manager.
   >>> nosm['root'] = myfolder11
   >>> myfolder11.getSiteManager().__bases__ == (gsm, )
   True
+
+Deleting a site unregisters its site manger from its parent site manager:
+
+  >>> del myfolder2['myfolder21']
+  >>> myfolder2.getSiteManager().subs
+  ()

--- a/src/zope/site/site.rst
+++ b/src/zope/site/site.rst
@@ -358,3 +358,8 @@ Deleting a site unregisters its site manger from its parent site manager:
   >>> del myfolder2['myfolder21']
   >>> myfolder2.getSiteManager().subs
   ()
+  
+The removed site manager now has no bases:
+
+  >>> myfolder21.getSiteManager().__bases__
+  ()


### PR DESCRIPTION
Fixes #1.

The implementation was originally taken from https://github.com/zopefoundation/grokcore.site/blob/fc945c90c5093de8f7ff958cf498eb6305b9c068/src/grokcore/site/subscriber.py#L35-L46 but changed in the review process of this PR.