### PR TITLE
On removal of site, clear bases of its site manager.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,9 @@ CHANGES
 3.10.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- On removal of a site, clear the bases of its site manager. This fixes a reference leak
+  from a parent site manager. See
+  `issue 1 <https://github.com/zopefoundation/zope.site/issues/1>`_.
 
 
 3.9.2 (2010-09-25)

--- a/src/zope/site/site.py
+++ b/src/zope/site/site.py
@@ -219,11 +219,14 @@ def SiteManagerAdapter(ob):
 
 def changeSiteConfigurationAfterMove(site, event):
     """After a site is moved, its site manager links have to be updated."""
+    local_sm = site.getSiteManager()
     if event.newParent is not None:
         next = _findNextSiteManager(site)
         if next is None:
             next = zope.component.getGlobalSiteManager()
-        site.getSiteManager().__bases__ = (next, )
+        local_sm.__bases__ = (next, )
+    else:
+        local_sm.__bases__ = ()
 
 
 @zope.component.adapter(

--- a/src/zope/site/site.txt
+++ b/src/zope/site/site.txt
@@ -276,7 +276,7 @@ site hierarchy is as follows:
 
            _____ global site _____
           /                       \
-      myfolder1                myfolder2
+      myfolder                 myfolder2
           |
       myfolder11
 
@@ -352,3 +352,14 @@ sitemanager's bases should be set to global site manager.
   >>> nosm['root'] = myfolder11
   >>> myfolder11.getSiteManager().__bases__ == (gsm, )
   True
+
+Deleting a site unregisters its site manger from its parent site manager:
+
+  >>> del myfolder2['myfolder21']
+  >>> myfolder2.getSiteManager().subs
+  ()
+  
+The removed site manager now has no bases:
+
+  >>> myfolder21.getSiteManager().__bases__
+  ()


### PR DESCRIPTION
This fixes a reference leak from a parent site manager.
See `issue 1 <https://github.com/zopefoundation/zope.site/issues/1>`.

Port #14 to 3.10.