### PR TITLE
Move IRoot ahead of IFolder in IRootFolder.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,17 +2,33 @@
  Changes
 =========
 
-4.4.1 (unreleased)
+4.5.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix the interface definition of ``IRootFolder`` to give ``IRoot``
+  higher priority than the folder and container interfaces. This is
+  what is usually expected, but not what the code defined. Commonly,
+  in the past, this problem was hidden because the factory function
+  ``rootFolder()`` re-arranged the interfaces to put ``IRoot`` at the
+  front. Under zope.interface 5's C3 resolution order, however, this
+  rearrangement was not taking place; thus, looking up adapters for a
+  ``rootFolder()`` object was likely to find adapters for
+  ``IItemContainer``  instead of adapters for ``IRoot`` as intended.
+
+  With this change, users of ``rootFolder()`` should notice no changes
+  compared with zope.interface 4. Code that has classes defined to
+  implement ``IRootFolder`` directly, though, may notice a different
+  resolution order on those objects (consistent with what
+  ``rootFolder()`` generates).
+
+  See `issue 17 <https://github.com/zopefoundation/zope.site/issues/17>`_.
 
 
 4.4.0 (2020-09-10)
 ==================
 
-- On removal of a site, clear the bases of its site manager. This fixes a reference leak 
-  from a parent site manager. See 
+- On removal of a site, clear the bases of its site manager. This fixes a reference leak
+  from a parent site manager. See
   `issue 1 <https://github.com/zopefoundation/zope.site/issues/1>`_.
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ TESTS_REQUIRE = [
 ]
 
 setup(name='zope.site',
-      version='4.4.1.dev0',
+      version='4.5.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Local registries for zope component architecture',

--- a/src/zope/site/interfaces.py
+++ b/src/zope/site/interfaces.py
@@ -83,5 +83,11 @@ class IFolder(zope.container.interfaces.IContainer,
     """The standard Zope Folder object interface."""
 
 
-class IRootFolder(IFolder, zope.location.interfaces.IRoot):
-    """The standard Zope root Folder object interface."""
+class IRootFolder(zope.location.interfaces.IRoot, IFolder):
+    """
+    The standard Zope root Folder object interface.
+
+    .. versionchanged:: 4.5.0
+       ``IRoot`` is now defined to come before ``IFolder`` in the
+        interface resolution (priority) order.
+    """

--- a/src/zope/site/tests/test_folder.py
+++ b/src/zope/site/tests/test_folder.py
@@ -22,6 +22,35 @@ class FolderTest(TestSiteManagerContainer):
         return Folder()
 
 
+class TestRootFolder(unittest.TestCase):
+
+    def test_IRoot_before_IContainer_rootFolder(self):
+        from zope.site.folder import rootFolder
+        from zope.interface import providedBy
+        from zope.location.interfaces import IRoot
+        from zope.container.interfaces import IContainer
+
+        folder = rootFolder()
+        provides = list(providedBy(folder).flattened())
+
+        iroot = provides.index(IRoot)
+        container = provides.index(IContainer)
+
+        self.assertLess(iroot, container)
+
+    def test_IRoot_before_IContainer_IRootFolder(self):
+        from zope.site.interfaces import IRootFolder
+        from zope.location.interfaces import IRoot
+        from zope.container.interfaces import IContainer
+
+        provides = list(IRootFolder.__iro__)
+
+        iroot = provides.index(IRoot)
+        container = provides.index(IContainer)
+
+        self.assertLess(iroot, container)
+
+
 def test_suite():
     flags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
     return unittest.TestSuite((


### PR DESCRIPTION
Give IRoot the priority its supposed to have.

Fixes #17

All tox environments pass locally (verified the new tests failed before changing `IRootFolder`).